### PR TITLE
refactor(config): rename vitest config files to follow dot notation p…

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,8 +39,8 @@
 		"release": "semantic-release",
 		"start": "node dist/index.js",
 		"test:all": "npm run test:unit && npm run test:e2e",
-		"test:e2e": "npm run build && vitest --config vitest.config.e2e.js --typecheck.tsconfig tsconfig.json",
-		"test:unit": "vitest run test/unit --config vitest.config.unit.js"
+		"test:e2e": "npm run build && vitest --config vitest.e2e.config.js --typecheck.tsconfig tsconfig.json",
+		"test:unit": "vitest run test/unit --config vitest.unit.config.js"
 	},
 	"config": {
 		"commitizen": {


### PR DESCRIPTION
…attern

Updated test script references to use vitest.e2e.config.js and vitest.unit.config.js instead of vitest.config.e2e.js and vitest.config.unit.js for better consistency with standard configuration file naming conventions.