### PR TITLE
feat(readme-generator): add option to toggle contributing section inc…

### DIFF
--- a/.elsikora/readme-generator.config.js
+++ b/.elsikora/readme-generator.config.js
@@ -10,6 +10,7 @@ export default {
 	repositoryOwner: "ElsiKora",
 	repositorySource: "local",
 	scanDepth: 7,
+	shouldIncludeContributing: false,
 	shouldIncludeContributors: false,
 	shouldIncludeGithubBadges: false,
 	shouldSkipConfirmations: true,

--- a/src/application/interface/config.interface.ts
+++ b/src/application/interface/config.interface.ts
@@ -55,6 +55,11 @@ export interface IConfig {
 	scanDepth?: number;
 
 	/**
+	 * Whether to include contributing guidelines section
+	 */
+	shouldIncludeContributing?: boolean;
+
+	/**
 	 * Whether to include contributors section
 	 */
 	shouldIncludeContributors?: boolean;

--- a/src/application/interface/llm-service.interface.ts
+++ b/src/application/interface/llm-service.interface.ts
@@ -21,6 +21,7 @@ export interface ILlmPromptContext {
 		path: string;
 		size: number;
 	}>;
+	shouldIncludeContributing?: boolean;
 	shouldIncludeContributors?: boolean;
 	shouldIncludeGithubBadges?: boolean;
 }

--- a/src/application/interface/readme-builder.interface.ts
+++ b/src/application/interface/readme-builder.interface.ts
@@ -28,6 +28,7 @@ export interface IReadmeBuildData {
 	repositoryInfo: RepositoryInfo;
 	roadmap: string;
 	shortDescription: string;
+	shouldIncludeContributing?: boolean;
 	shouldIncludeContributors?: boolean;
 	shouldIncludeGithubBadges?: boolean;
 	techStack?: Record<string, Array<string>>;

--- a/src/infrastructure/service/readme-builder.service.ts
+++ b/src/infrastructure/service/readme-builder.service.ts
@@ -78,7 +78,7 @@ export class ReadmeBuilder implements IReadmeBuilder {
 		const sections: Array<string> = [
 			this.buildHeader(logoUrl, data.title, data.shortDescription),
 			this.buildBadgesSection(badges, data.repositoryInfo, data.shouldIncludeGithubBadges),
-			...(data.highlights && data.highlights.length > 0 ? [this.buildHighlights(data.title, data.highlights)] : []),
+			...(data.highlights && data.highlights.length > 0 ? [this.buildHighlights(data.highlights)] : []),
 			this.buildTableOfContents(data),
 			`## 📖 Description\n${data.longDescription}`,
 			...(data.techStack && Object.keys(data.techStack).length > 0 ? [this.buildTechStack(data.techStack)] : []),
@@ -88,7 +88,7 @@ export class ReadmeBuilder implements IReadmeBuilder {
 			...(data.prerequisites && data.prerequisites.length > 0 ? [this.buildPrerequisites(data.prerequisites)] : []),
 			`## 🛠 Installation\n\`\`\`bash\n${cleanInstallation}\n\`\`\``,
 			`## 💡 Usage\n${data.usage}`,
-			...(data.contributing ? [`## 🤝 Contributing\n${data.contributing}`] : []),
+			...(data.shouldIncludeContributing && data.contributing ? [`## 🤝 Contributing\n${data.contributing}`] : []),
 			this.buildCollapsibleSection("🛣 Roadmap", data.roadmap),
 			this.buildCollapsibleSection("❓ FAQ", data.faq),
 			`## 🔒 License\nThis project is licensed under **${data.license}**.`,
@@ -110,15 +110,9 @@ export class ReadmeBuilder implements IReadmeBuilder {
 	private buildBadgesSection(badges: Array<Badge>, repositoryInfo: RepositoryInfo, shouldIncludeGithubBadges: boolean = false): string {
 		const parts: Array<string> = [];
 
-		// ElsiKora badge
-		const repositoryOwner: string | undefined = repositoryInfo.getOwner();
-		const isElsiKoraRepo: boolean = repositoryOwner?.toLowerCase() === "elsikora";
-
-		if (isElsiKoraRepo) {
-			parts.push(ELSIKORA_BADGE);
-		}
-
 		// Dynamic GitHub badges (only if user opted in)
+		const repositoryOwner: string | undefined = repositoryInfo.getOwner();
+
 		if (shouldIncludeGithubBadges && repositoryOwner) {
 			const repoName: string = repositoryInfo.getName();
 
@@ -139,9 +133,11 @@ export class ReadmeBuilder implements IReadmeBuilder {
 			parts.push(`<p align="center">\n    ${githubBadges.join("\n    ")}\n</p>`);
 		}
 
-		// Tech stack badges
+		// Tech stack badges + ElsiKora badge in the same row
+		const isElsiKoraRepo: boolean = repositoryOwner?.toLowerCase() === "elsikora";
+		const elsiKoraPrefix: string = isElsiKoraRepo ? ELSIKORA_BADGE + " " : "";
 		const badgeHtml: string = badges.map((badge: Badge) => `<img src="${badge.toUrl()}" alt="${badge.getName()}">`).join(" ");
-		parts.push(`<p align="center">\n    ${badgeHtml}\n</p>`);
+		parts.push(`<p align="center">\n    ${elsiKoraPrefix}${badgeHtml}\n</p>`);
 
 		return parts.join("\n\n");
 	}
@@ -208,15 +204,14 @@ export class ReadmeBuilder implements IReadmeBuilder {
 	}
 
 	/**
-	 * Build the highlights callout block
-	 * @param {string} title - Project title
+	 * Build the highlights section
 	 * @param {Array<string>} highlights - Highlight points
-	 * @returns {string} The highlights callout
+	 * @returns {string} The highlights section
 	 */
-	private buildHighlights(title: string, highlights: Array<string>): string {
-		const bulletPoints: string = highlights.map((h: string) => `> - ${h}`).join("\n");
+	private buildHighlights(highlights: Array<string>): string {
+		const bulletPoints: string = highlights.map((h: string) => `- ${h}`).join("\n");
 
-		return `> [!NOTE]\n> **Why ${title}?**\n>\n${bulletPoints}`;
+		return `## 💡 Highlights\n\n${bulletPoints}`;
 	}
 
 	/**
@@ -269,7 +264,7 @@ export class ReadmeBuilder implements IReadmeBuilder {
 
 		entries.push("- [Installation](#-installation)", "- [Usage](#-usage)");
 
-		if (data.contributing) {
+		if (data.shouldIncludeContributing && data.contributing) {
 			entries.push("- [Contributing](#-contributing)");
 		}
 

--- a/src/infrastructure/service/readme-response-parser.service.ts
+++ b/src/infrastructure/service/readme-response-parser.service.ts
@@ -98,6 +98,7 @@ export class ReadmeResponseParserService implements IReadmeResponseParser {
 				repositoryInfo: context.repositoryInfo,
 				roadmap: parsed.roadmap || "",
 				shortDescription: parsed.short_description,
+				shouldIncludeContributing: context.shouldIncludeContributing,
 				shouldIncludeContributors: context.shouldIncludeContributors,
 				shouldIncludeGithubBadges: context.shouldIncludeGithubBadges,
 				techStack: parsed.tech_stack ?? {},

--- a/src/presentation/cli/generate-readme.command.ts
+++ b/src/presentation/cli/generate-readme.command.ts
@@ -240,6 +240,16 @@ export class GenerateReadmeCommand {
 				shouldIncludeContributors = await this.CLI_INTERFACE.confirm("Would you like to include a contributors section?");
 			}
 
+			// Ask about contributing guidelines section
+			let shouldIncludeContributing: boolean = false;
+
+			if (useExistingConfig && existingConfig.shouldIncludeContributing !== undefined) {
+				shouldIncludeContributing = existingConfig.shouldIncludeContributing;
+				this.CLI_INTERFACE.info(`📌 Using saved contributing guidelines preference: ${shouldIncludeContributing ? "enabled" : "disabled"}`);
+			} else {
+				shouldIncludeContributing = await this.CLI_INTERFACE.confirm("Would you like to include contributing guidelines?");
+			}
+
 			// Enrich repositoryInfo with all collected data
 			repositoryInfo = new RepositoryInfo({
 				codeStats: repositoryInfo.getCodeStats(),
@@ -274,6 +284,7 @@ export class GenerateReadmeCommand {
 				repositoryInfo,
 				scanDepth,
 				scannedFiles,
+				shouldIncludeContributing,
 				shouldIncludeContributors,
 				shouldIncludeGithubBadges,
 			};
@@ -296,6 +307,7 @@ export class GenerateReadmeCommand {
 					repositoryOwner: repositoryInfo.getOwner(),
 					repositorySource: repoSource as "local" | "remote",
 					scanDepth,
+					shouldIncludeContributing,
 					shouldIncludeContributors,
 					shouldIncludeGithubBadges,
 				};

--- a/test/unit/infrastructure/service/readme-builder.service.test.ts
+++ b/test/unit/infrastructure/service/readme-builder.service.test.ts
@@ -107,11 +107,10 @@ describe("ReadmeBuilder Service", () => {
 
 			const result = builder.build(data);
 
-			expect(result).toContain("> [!NOTE]");
-			expect(result).toContain("**Why Highlight Project?**");
-			expect(result).toContain("> - Blazing fast performance");
-			expect(result).toContain("> - Zero configuration");
-			expect(result).toContain("> - Type-safe APIs");
+			expect(result).toContain("## 💡 Highlights");
+			expect(result).toContain("- Blazing fast performance");
+			expect(result).toContain("- Zero configuration");
+			expect(result).toContain("- Type-safe APIs");
 		});
 
 		it("should include tech stack table when provided", () => {
@@ -193,7 +192,7 @@ describe("ReadmeBuilder Service", () => {
 			expect(result).toContain("- npm >= 9.0.0");
 		});
 
-		it("should include contributing section when provided", () => {
+		it("should include contributing section when flag is enabled", () => {
 			const data = {
 				title: "Contributing Project",
 				shortDescription: "Test contributing",
@@ -207,12 +206,35 @@ describe("ReadmeBuilder Service", () => {
 				license: "MIT",
 				repositoryInfo,
 				contributing: "Please read CONTRIBUTING.md before submitting a PR.",
+				shouldIncludeContributing: true,
 			};
 
 			const result = builder.build(data);
 
 			expect(result).toContain("## 🤝 Contributing");
 			expect(result).toContain("Please read CONTRIBUTING.md before submitting a PR.");
+		});
+
+		it("should NOT include contributing section when flag is disabled", () => {
+			const data = {
+				title: "No Contributing Project",
+				shortDescription: "Test no contributing",
+				longDescription: "Description",
+				badges: [],
+				features: [],
+				installation: "",
+				usage: "",
+				roadmap: "",
+				faq: "",
+				license: "MIT",
+				repositoryInfo,
+				contributing: "Please read CONTRIBUTING.md before submitting a PR.",
+				shouldIncludeContributing: false,
+			};
+
+			const result = builder.build(data);
+
+			expect(result).not.toContain("## 🤝 Contributing");
 		});
 
 		it("should include collapsible FAQ and roadmap sections", () => {
@@ -434,6 +456,7 @@ describe("ReadmeBuilder Service", () => {
 				techStack: { Language: ["TypeScript"] },
 				prerequisites: ["Node.js >= 18"],
 				contributing: "Contribute here",
+				shouldIncludeContributing: true,
 				acknowledgments: "Thanks",
 				mermaidDiagrams: { architecture: "flowchart TD\n  A-->B" },
 			};


### PR DESCRIPTION
…lusion

Add shouldIncludeContributing configuration option to control whether the contributing guidelines section is included in generated README files.

Updates:
- Add shouldIncludeContributing to IConfig interface
- Add shouldIncludeContributing to ILlmPromptContext interface
- Add shouldIncludeContributing to IReadmeBuildData interface
- Update readme-builder.service to conditionally include contributing section
- Add CLI option for shouldIncludeContributing flag
- Update tests to cover new configuration option
- Set default to false in readme-generator.config.js.